### PR TITLE
Makefile Looks for Headers and changes therein

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ df = $(MODEL_BUILD_TMP)/$(*F)
 
 # Compiler Flags
 CC=gcc
-CFLAGS = -Wall -O0 -g -m32
+CFLAGS = -Wall -O0 -m32
 LDFLAGS = -lm
 MAKEDEPEND = gcc -MM -MT '$(MODEL_BUILD_TMP)/$*.o' $(CPPFLAGS) -o $(MODEL_BUILD_TMP)/$*.d $<
 


### PR DESCRIPTION
OK. I added a little bit to the Makefile which should fix this:

When the makefile builds an object file this now happens:
i.e. `$ make closeall.o`

1) gcc generates a list of header files which are included in `closeall.c`
2) This file is formatted as a make target for closeall.o, and put into `build/closeall.P`
3) Gcc compiles `src/closeall.c` into `build.closeall.o`

Say we change `variabex.h`, and recompile. The following happens:

1) Make looks at `build/closeall.P`, and acts as though the the text in `closeall.P` is written in `Makefile`
2) Make looks at the prerequisites for `build/closeall.o`. The file `closeall.P` tells Make that `variabex.h`
is a prerequisite, and has changed.
3) Make rebuilds `closeall.o`

This happens for any object or binary that we (or make) care about. The nice thing about this approach is that
we don't need to update the Makefile every time a new header file is added as a prerequisite to some file.

I also made a change so that the debug files (`.dSym`) are not generated by default.
