### PR TITLE
Version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Overview
 - Distributed Energy Balance Model (DEBaM)
 - Distributed Enhanced Temperature Index Model (DETIM)
 
-### v2.0.0
+### v2.0.1
 
 
 The models compute glacier surface mass balance (ablation and accumulation) and

--- a/changes.md
+++ b/changes.md
@@ -8,7 +8,7 @@ The term in brackets is used to mark each change.
 
 
 #### 5 November 2013: (ERROR, R. Hock)
-* v2.0.0
+* v2.0.1
  - ERROR fixed in computing number of valid time steps of discharge data. Affects r2 slightly and cumulative measured discharge volume in discharge output. (Version number not changed).
 
 


### PR DESCRIPTION
The error fixes made on 5 November 2013 garner a bump in the  PATCH number, which puts the model at v2.0.1.
