### PR TITLE
Reformatted modelperformance.txt for machine/human readability.

### DIFF
--- a/src/writeout.c
+++ b/src/writeout.c
@@ -2226,7 +2226,6 @@ void writeperformance()
             exit(4);
         }  /*ENDIF*/
 
-        fprintf(outperformance,"Q_r2 Q_lnr2 Qvolumesim  Qvolumemeas  Difference(sim-meas)  nsteps  nstepsdis totalglacierwidemassbalance(m)\n");
         fprintf(outperformance,"r2 is Nash-Sutcliffe efficiency criterion for discharge Q (-infinity to 1), discharge volumes are in 100,000 m3\n"); 
         fprintf(outperformance,"nsteps = number modeled time steps, nstepsdis = number of time steps with valid discharge data - must be the same for the volume difference to make sense\n");
 
@@ -2242,7 +2241,14 @@ void writeperformance()
       }
 
       /*cumulative mass balance over entire modeling period written to output for comparison with geodetic longer-term balance, converted to m*/
-     fprintf(outperformance,"%.3f\t %.3f\t  %.3f\t %.3f\t %.3f   %d  %d  %10.3f\n",r2value,r2lnvalue,volumesim,volumemeas,diffvolume,nsteps,nstepsdis,areamassbalcum/100);
+     fprintf(outperformance,"Q_r2\t%.6f\n", r2value);
+     fprintf(outperformance,"Q_lnr2\t%.6f\n", r2lnvalue);
+     fprintf(outperformance,"Qvolumesim\t%.6f\n", volumesim);
+     fprintf(outperformance,"Qvolumemeas\t%.6f\n", volumemeas);
+     fprintf(outperformance,"Difference(sim-meas)\t%.6f\n", diffvolume);
+     fprintf(outperformance,"nsteps\t%i\n", nsteps);
+     fprintf(outperformance,"nstepsdis\t%i\n", nstepsdis);
+     fprintf(outperformance, "totalglacierwidemassbalance(m)\t%.6f",areamassbalcum/100); 
      fclose(outperformance);
     }  /*endif*/
     


### PR DESCRIPTION
Values are now output in a

key\t value

format which makes it easy for us to read it, and add more values as we see fit, without needing to rewrite the script which reads the file. 
