### PR TITLE
Proposed fix to issue #43 .

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@ Overview
 - Distributed Energy Balance Model (DEBaM)
 - Distributed Enhanced Temperature Index Model (DETIM)
 
-### v2.1.0
+### v2.1.1
 
 The models compute glacier surface mass balance (ablation and accumulation) and
-discharge, with hourly to daily resolution. 
+discharge, with hourly to daily resolution.
 The mass balance model is fully distributed, i.e. calculations are performed for each grid cell of a
 digital elevation model. Discharge is calculated from the water provided by melt plus liquid precipitation by three
 linear reservoirs corresponding to the different storage properties of firn,
@@ -26,7 +26,7 @@ by Carleen Tijm-Reijmer, Utrecht University.
 
 - __DEBaM__ computes surface melt by an energy balance approach.
 
-- __DETIM__ offers various temperature index methods approaches. 
+- __DETIM__ offers various temperature index methods approaches.
 
 
 Download
@@ -38,7 +38,7 @@ running:
 
 from a terminal. If you plan to modify the source, or contribute to the
 project, this is the preferred method. More information about git can be
-found at [git-scm](http://git-scm.com/) or at 
+found at [git-scm](http://git-scm.com/) or at
 [Github](http://help.github.com/articles/).
 
 Installation
@@ -46,7 +46,7 @@ Installation
 
 Prerequisites:
 
-* A working C compiler 
+* A working C compiler
 
 To build DeBAM and DETIM, do
 
@@ -54,14 +54,14 @@ To build DeBAM and DETIM, do
     $ make all
 
 The model executables will now be located in ```meltmodel/bin```
- 
+
 A more complete installation guide is available in install.md.
 
 Additional Information
 ----------------------
 
 For further information contact [Regine Hock](http://gi.alaska.edu/~regine/),
-(University of Alaska, Fairbanks) or Carleen Tijm-Reijmer 
+(University of Alaska, Fairbanks) or Carleen Tijm-Reijmer
 (University Utrecht). Note that the model may
 contain errors and the model manual may not be complete or outdated. User
 support and further code improvements are available in direct collaboration

--- a/changes.md
+++ b/changes.md
@@ -5,10 +5,14 @@ NOTE: Changes in the code can be due to
 
 The term in brackets is used to mark each change.
 
+#### 21 January 2015: (ERROR, L. Gillispie)
+* v2.1.1
+  - fixes an un-allocated pointer error which caused segmentation faults in certain circumstances
+
 #### 15 January 2015: (NEW, C. Reijmer)
 * v2.1.0
   - changes in subsurface model: renmaing variables and writing more variables to output so that the water and energy balance can be tracked better.
-  
+
 #### 6 November 2013: (NEW, R. Hock)
 * v2.0.2
  - change in output file "modelperformance.txt", discharge volume discharge is set to -9999 if discharge measurements contain missing values during simulation period (if nstepsdis < nsteps)
@@ -26,8 +30,8 @@ The term in brackets is used to mark each change.
 - ERROR FIXED: cumulative mass balances for stakes (cummassbal.txt) was reset to 0 at end of mass balance year. Fixed so that it is continuous.
 - ERROR FIXED: precipitation correction factor was not applied when precipitation was read from file for energy balance model.
 - TECHNICAL: filenames of default output files changes:
-     melting.txt        → cumablation.txt, 
-     specificmassbal.txt → seasonalmassbal.txt, 
+     melting.txt        → cumablation.txt,
+     specificmassbal.txt → seasonalmassbal.txt,
      res.out  	        → modellog.txt
 - TECHNICAL: NEW: Longwave incoming radiation grid array is used even if LWin is spatially constant
 
@@ -45,7 +49,7 @@ to the text file "model_performance.txt"
 * v1.0.1
    Bug fixed in the skin layer formulation responsible for the lack of closure of the surface energy balance as found in the output.
 - Added MBsum in order to have mass balance output consistent with other mass balance parameters output.
-- Made changes (together with Torbjorn Ostby) to functions meltlayermice and resetgridwinter to remove 
+- Made changes (together with Torbjorn Ostby) to functions meltlayermice and resetgridwinter to remove
 some bugs related to the sr50 output. Correspondence between mass balance output and sr50 has improved.
 - Made changes to functions subsurf and surftempskin to correct a bug resulting in wrong surface temperature to be used to calculate the sensible and latent heat flux. As a result energy balance was not 0 for T<0. This is fixed now.
 
@@ -101,12 +105,12 @@ some bugs related to the sr50 output. Correspondence between mass balance output
 * Github hosting!
 
 * Executable rename:
-    - ```degree``` is now known as the Distributed Enhanced Temperature Index 
+    - ```degree``` is now known as the Distributed Enhanced Temperature Index
     Model (DeTIM), and has executable ```detim```
 
     - ```meltmod``` is now know as the Distributed Energy Balance Model (DEBaM),
     and has executable ```debam```
- 
+
 
 * Build system in place! MeltMod now uses cmake to configure its builds.
     - Adds portability, cmake generates makefiles with the current environment
@@ -128,7 +132,7 @@ some bugs related to the sr50 output. Correspondence between mass balance output
 * Bug fixes: closed the following issues
     - issue #10 : ``readprecipindexmap`` was reading the wrong file, this is fixed
     - issue #11 : ``shayes`` is turned off when executing the temperature index model
-    - issue #12 : ``methodsurftemp`` is immediately set to ``1`` when running the 
+    - issue #12 : ``methodsurftemp`` is immediately set to ``1`` when running the
         temperature index model, this was happening later, and screwing up some
         initialization parameters
     - issue #13 : fixed typo in snow-cover initialization
@@ -140,13 +144,13 @@ Which brings us to...
 * Project Reorganization:
     - All model source files are now located in the ```src/``` folder in the
         project root
-    - Utility programs related to the project are located in the ```util/``` folder 
+    - Utility programs related to the project are located in the ```util/``` folder
     - Tests and their related file are located in the ```test/``` folder
 
 * Code reorganization
     - All functions relating to matrix and tensor manipulation have been moved into
         it's own file: grid.c/h and included where necessary. Before, these were
         spread through a few different files, having them in one place makes sense.
-    - issue #9: Redundant long ints ```nrl,nrh,ncl,nch,ndl``` and ```ndh``` used for 
+    - issue #9: Redundant long ints ```nrl,nrh,ncl,nch,ndl``` and ```ndh``` used for
         matrix/tensor sizing were removed, matrix
         allocation and deallocation now take integers as arguments.

--- a/src/closeall.c
+++ b/src/closeall.c
@@ -1,23 +1,23 @@
 /**********************************************************************
  * Copyright 1995-2012 Regine Hock, Carleen Tijm-Reijmer
- * 
+ *
  * This file is part of DeBAM and DETiM.
- * 
+ *
  * This is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This software is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with This software.  If not, see <http://www.gnu.org/licenses/>.
  **********************************************************************/
 /* last update 13 June 2013*/
- 
+
 /*******************************************************************/
 /*  FILE   closeall.c                                              */
 /*                                                                 */
@@ -347,7 +347,7 @@ void closeall()
         freematrix(MASSBALcum,1,nrows,1,ncols);
         freematrix(MASSBALcum_all,1,nrows,1,ncols);
         freematrix(MASSBALgrid,1,nrows,1,ncols);
-        
+
     free(namedgm);
     free(namedgmdrain);
     free(namedgmglac);
@@ -380,7 +380,6 @@ void closeall()
             freematrixdouble(r2ln,1,anzahlopt1,1,anzahlopt2);
             freematrixdouble(f02ln,1,anzahlopt1,1,anzahlopt2);
 
-            fclose(qmeasfile);
         }
 
         if ((disyesopt == 1) || (ddfoptyes == 1)) { /*only optimization run*/
@@ -398,4 +397,3 @@ void closeall()
     return;
 
 }
-

--- a/src/variab.h
+++ b/src/variab.h
@@ -2,17 +2,17 @@
  * Copyright 1996-2012 Regine Hock
  *
  * This file is part of DeBAM and DETiM.
- * 
+ *
  * This is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This software is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with This software.  If not, see <http://www.gnu.org/licenses/>.
  **********************************************************************/
@@ -424,7 +424,6 @@ float  **RAIN;        /*grid of liquid precipitation*/
 
 FILE   *firnfile;
 FILE   *qcalcfile;       /*Output file of calculated discharge*/
-FILE   *qmeasfile;       /*Input file of measured discharge*/
 float   **FIRN;          /*thickness of firn cover*/
 double  **qfirnopt,**qsnowopt,**qiceopt,**qrockopt;  /*for optimization*/
 double  **f2,**sumf0x,**sumf0x2;
@@ -608,7 +607,7 @@ float  **GLOBALsum;		/* 2-D-Arrays for radiation */
 float  **SENSIBLEsum,**LATENTsum;        /* 2-D-Array for turbulent fluxes */
 float  **rainenergysum;
 float  **ICEHEATsum;
-double **SUBLIMATIONsum;  /*sum of mass condensated or sublimated*/ 
+double **SUBLIMATIONsum;  /*sum of mass condensated or sublimated*/
 double **SUBLIMATION;		/*mass sublimated or condensated*/
 float  **REFLECTsum;		/*Reflected solar radiation, used for averaging over subtime step*/
 float  **superice;          /*layer thickness superimposed ice in m ice*/

--- a/src/variabex.h
+++ b/src/variabex.h
@@ -1,17 +1,17 @@
 /***********************************************************************
  * Copyright 1996-2012 Regine Hock
  * This file is part of DeBAM and DETiM.
- * 
+ *
  * This is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This software is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with This software.  If not, see <http://www.gnu.org/licenses/>.
  **********************************************************************/
@@ -412,7 +412,6 @@ extern float  **RAIN;        /*grid of liquid precipitation*/
 
 extern FILE   *firnfile;
 extern FILE   *qcalcfile;       /*Output file of calculated discharge*/
-extern FILE   *qmeasfile;       /*Input file of measured discharge*/
 extern float   **FIRN;
 extern double  **qfirnopt,**qsnowopt,**qiceopt,**qrockopt;  /*for optimization*/
 extern double  **f2,**sumf0x,**sumf0x2;
@@ -588,7 +587,7 @@ extern float  **GLOBALsum;		/* 2-D-Arrays for radiation */
 extern float  **SENSIBLEsum,**LATENTsum;        /* 2-D-Array for turbulent fluxes */
 extern float  **rainenergysum;
 extern float  **ICEHEATsum;
-extern double **SUBLIMATIONsum;  /*sum of mass condensated or sublimated*/ 
+extern double **SUBLIMATIONsum;  /*sum of mass condensated or sublimated*/
 extern double **SUBLIMATION;		/*mass sublimated or condensated*/
 extern float  **REFLECTsum;		/*Reflected solar radiation, used for averaging over subtime step*/
 extern float  **superice;          /*layer thickness superimposed ice in m ice*/


### PR DESCRIPTION
This is proposed to fix issue 43, and bump the version number accordingly.
This removes the variable qmeasfile and the fclose call which causes segfaults on some linux platforms.